### PR TITLE
Get Postgres include path automatically

### DIFF
--- a/src/pg_rrule.pro
+++ b/src/pg_rrule.pro
@@ -19,7 +19,7 @@ macx {
 }
 
 unix:!macx {
-    INCLUDEPATH += "/usr/include/postgresql/server"
+    INCLUDEPATH += $$system(pg_config --includedir-server)
 
     LIBS += -lpq -lical
 


### PR DESCRIPTION
Get the Postgres server include path via pg_config instead of hardcoding it.